### PR TITLE
allow to override sendfile option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,7 @@ class nginx (
   $nginx_upstreams        = {},
   $nginx_locations        = {},
   $manage_repo            = $nginx::params::manage_repo,
+  $sendfile               = $nginx::params::nx_sendfile
 ) inherits nginx::params {
 
   include stdlib

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -16,7 +16,7 @@ http {
 
   access_log  <%= @http_access_log %>;
 
-  sendfile    <%= scope.lookupvar('nginx::params::nx_sendfile')%>;
+  sendfile    <%= scope.lookupvar('nginx::sendfile')%>;
 
   server_tokens <%= @server_tokens %>;
   <% if scope.lookupvar('nginx::params::nx_tcp_nopush') == 'on' %>tcp_nopush on;<% end %>


### PR DESCRIPTION
It can be useful because of bug in virtualbox(sendfile does not work, and needs to be disabled):
https://www.virtualbox.org/ticket/9069
