### PR TITLE
Fix deprecated variable access warning in vhost header template

### DIFF
--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -14,7 +14,7 @@ server {
 <%# make sure that allow comes before deny by forcing the allow key (if it -%>
 <%# exists) to be first in the output order.  The hash keys also need to be -%>
 <%# sorted so that the ordering is stable. -%>
-<% if @vhost_cfg_prepend -%><% vhost_cfg_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
+<% if @vhost_cfg_prepend -%><% @vhost_cfg_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
   <%= key %> <%= value %>;
 <% end -%><% end -%>
 <% if @root -%>


### PR DESCRIPTION
Fixes the warning

```
Warning: Variable access via 'vhost_cfg_prepend' is deprecated. Use '@vhost_cfg_prepend' instead. 
template[/etc/puppet/modules/nginx/templates/vhost/vhost_header.erb]:17
   (at /etc/puppet/modules/nginx/templates/vhost/vhost_header.erb:17:in `result')
```
